### PR TITLE
 helper/gpt.go

### DIFF
--- a/command/diff.go
+++ b/command/diff.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"ggt/helper"
 	"ggt/tools"
+	"ggt/types"
 	"os"
 
 	"github.com/urfave/cli"
@@ -33,8 +34,17 @@ func Diff() cli.Command {
 			ai := helper.NewOpenAI(cfg.Open.Token)
 			answer, err := ai.Diff(content)
 			if err != nil {
-				tools.ErrorDescAndLogin("Diff", err)
-				os.Exit(1)
+				switch err.(type) {
+				case *types.GptError:
+					fmt.Fprintf(os.Stderr, "GPT error: %s\n", err.Error())
+					os.Exit(1)
+				case *types.LoginError:
+					fmt.Fprintf(os.Stderr, "Login error: %s\n", err.Error())
+					os.Exit(1)
+				default:
+					fmt.Fprintf(os.Stderr, "Unknown error: %s\n", err.Error())
+					os.Exit(1)
+				}
 			}
 
 			fmt.Println("---------------------------------")

--- a/helper/gpt.go
+++ b/helper/gpt.go
@@ -31,7 +31,10 @@ func (ai *OpenAI) Diff(diff map[string]string) (answer string, err error) {
 		ai.WithUserPrompt(fmt.Sprintf(types.DiffUserPrompt, file, content))
 		_answer, err := ai.do(types.DiffMaxTokens)
 		if err != nil {
-			return "", err
+			return "", &types.GptError{
+				Err:  err,
+				Code: types.GptFailedError,
+			}
 		}
 
 		answer = fmt.Sprintf("%s\n\t%s\n%s", answer, file, _answer)
@@ -127,6 +130,10 @@ func (ai *OpenAI) do(maxTokens int) (answer string, err error) {
 	err = json.Unmarshal([]byte(str), &gptResponse)
 	if err != nil {
 		return "", err
+	}
+
+	if gptResponse.Error.Message != "" {
+		return "", fmt.Errorf("%v", gptResponse.Error)
 	}
 
 	return gptResponse.Choices[0].Message.Content, nil

--- a/types/error.go
+++ b/types/error.go
@@ -1,0 +1,29 @@
+package types
+
+const (
+	GptFailedError = 1001
+	UserLoginError = 1002
+)
+
+// GptError is a custom error type
+// It contains the error message and the error code
+type GptError struct {
+	Err  error
+	Code int
+}
+
+func (e *GptError) Error() string {
+	return e.Err.Error()
+}
+
+// LoginError is a custom error type
+// It contains the error message and the error code
+// This error need user login first
+type LoginError struct {
+	Err  error
+	Code int
+}
+
+func (e *LoginError) Error() string {
+	return e.Err.Error()
+}

--- a/types/git.go
+++ b/types/git.go
@@ -28,6 +28,7 @@ func GitDirIgnoreList() []string {
 		"vendor",
 		"node_modules",
 		"bin",
+		".DS_Store",
 	}
 }
 


### PR DESCRIPTION
Commit message:

Add error handling for GPT API response in helper/gpt.go

This commit adds error handling for the GPT-3.5 API response by wrapping the returned error with a custom error type and returning it to the caller function where this function is called. The commit also checks if there is any error message in the GPT-3.5 API response, and if present, returns an error using fmt.Errorf() instead of just returning the error string.
	types/error.go
Commit message: Add custom error types and error codes in types/error.go
	types/git.go
Commit message:
Update git.go file in types package to include ".DS_Store" in GitDirIgnoreList.
	command/diff.go
Commit message:

Add `types` package to import list and handle different types of errors in Diff function

Changes have been made to the `diff.go` file wherein the `types` package has been added to the import list. Additionally, error handling has been improved by adding a switch case statement that handles different types of errors in the `Diff()` function. This commit will help improve code quality and reduce potential errors during runtime.